### PR TITLE
Fix for parentheses in object identity.

### DIFF
--- a/MAdCaP.ps1
+++ b/MAdCaP.ps1
@@ -1445,86 +1445,94 @@ function Update-Display
 	if (($AD_count -eq 1) -and ($CA_count -eq 0))
 	{
 		$AD_name = $AnalogDeviceListbox.SelectedItem
-		if ($AD_name -ne "")
-		{
-			# Then they've not selected the first, empty value
-			$SelectedAD = $Global:ADs | where-object {$_.Identity -match $AD_name}
-			$OutputBox.Text = ($SelectedAD | Format-List | Out-String).Trim()
-			if ($SelectedAD.DialPlan -eq $null)
-			{
-				$DialPlanListbox.SelectedIndex = $DialPlanListbox.findstring("<Automatic>")
-			}
-			else
-			{
-				$DialPlanListbox.SelectedIndex = $DialPlanListbox.findstring("$($SelectedAD.DialPlan)")
-			}
-			if ($SelectedAD.VoicePolicy -eq $null)
-			{
-				$VoicePolicyListbox.SelectedIndex = $VoicePolicyListbox.findstring("<Automatic>")
-			}
-			else
-			{
-				$VoicePolicyListbox.SelectedIndex = $VoicePolicyListbox.findstring("$($SelectedAD.VoicePolicy)")
-			}
-			if ($SelectedAD.ClientPolicy -eq $null)
-			{
-				$ClientPolicyListbox.SelectedIndex = $ClientPolicyListbox.findstring("<Automatic>")
-			}
-			else
-			{
-				$ClientPolicyListbox.SelectedIndex = $ClientPolicyListbox.findstring("$($SelectedAD.ClientPolicy)")
-			}
-			if ($SelectedAD.LocationPolicy -eq $null)
-			{
-				$LocationPolicyListbox.SelectedIndex = $LocationPolicyListbox.findstring("<Automatic>")
-			}
-			else
-			{
-				$LocationPolicyListbox.SelectedIndex = $LocationPolicyListbox.findstring("$($SelectedAD.LocationPolicy)")
-			}
-		}
+    if ($AD_name -ne "")
+    {
+      # Then they've not selected the first, empty value
+      
+      # First lest escape anything funny in the ID that might annoy the Where-Object -match
+      $AD_name = [regex]::Escape($AD_name)
+      
+      $SelectedAD = $Global:ADs | where-object {$_.Identity -match $AD_name}
+      $OutputBox.Text = ($SelectedAD | Format-List | Out-String).Trim()
+      if ($SelectedAD.DialPlan -eq $null)
+      {
+        $DialPlanListbox.SelectedIndex = $DialPlanListbox.findstring("<Automatic>")
+      }
+      else
+      {
+        $DialPlanListbox.SelectedIndex = $DialPlanListbox.findstring("$($SelectedAD.DialPlan)")
+      }
+      if ($SelectedAD.VoicePolicy -eq $null)
+      {
+        $VoicePolicyListbox.SelectedIndex = $VoicePolicyListbox.findstring("<Automatic>")
+      }
+      else
+      {
+        $VoicePolicyListbox.SelectedIndex = $VoicePolicyListbox.findstring("$($SelectedAD.VoicePolicy)")
+      }
+      if ($SelectedAD.ClientPolicy -eq $null)
+      {
+        $ClientPolicyListbox.SelectedIndex = $ClientPolicyListbox.findstring("<Automatic>")
+      }
+      else
+      {
+        $ClientPolicyListbox.SelectedIndex = $ClientPolicyListbox.findstring("$($SelectedAD.ClientPolicy)")
+      }
+      if ($SelectedAD.LocationPolicy -eq $null)
+      {
+        $LocationPolicyListbox.SelectedIndex = $LocationPolicyListbox.findstring("<Automatic>")
+      }
+      else
+      {
+        $LocationPolicyListbox.SelectedIndex = $LocationPolicyListbox.findstring("$($SelectedAD.LocationPolicy)")
+      }
+    }
 	}
 	elseif (($AD_count -eq 0) -and ($CA_count -eq 1))
 	{
 		$CA_name = $CommonAreaPhoneListbox.SelectedItem
-		if ($CA_name -ne "")
-		{
-			# Then they've not selected the first, empty value
-			$SelectedCAP = $Global:CAPs | where-object {$_.Identity -match $CA_name}
-			$OutputBox.Text = ($SelectedCAP | Format-List | Out-String).Trim()
-			if ($SelectedCAP.DialPlan -eq $null)
-			{
-				$DialPlanListbox.SelectedIndex = $DialPlanListbox.findstring("<Automatic>")
-			}
-			else
-			{
-				$DialPlanListbox.SelectedIndex = $DialPlanListbox.findstring("$($SelectedCAP.DialPlan)")
-			}
-			if ($SelectedCAP.VoicePolicy -eq $null)
-			{
-				$VoicePolicyListbox.SelectedIndex = $VoicePolicyListbox.findstring("<Automatic>")
-			}
-			else
-			{
-				$VoicePolicyListbox.SelectedIndex = $VoicePolicyListbox.findstring("$($SelectedCAP.VoicePolicy)")
-			}
-			if ($SelectedCAP.ClientPolicy -eq $null)
-			{
-				$ClientPolicyListbox.SelectedIndex = $ClientPolicyListbox.findstring("<Automatic>")
-			}
-			else
-			{
-				$ClientPolicyListbox.SelectedIndex = $ClientPolicyListbox.findstring("$($SelectedCAP.ClientPolicy)")
-			}
-			if ($SelectedCAP.LocationPolicy -eq $null)
-			{
-				$LocationPolicyListbox.SelectedIndex = $LocationPolicyListbox.findstring("<Automatic>")
-			}
-			else
-			{
-				$LocationPolicyListbox.SelectedIndex = $LocationPolicyListbox.findstring("$($SelectedCAP.LocationPolicy)")
-			}
-		}
+    if ($CA_name -ne "")
+    {
+      # Then they've not selected the first, empty value
+      
+      # First lest escape anything funny in the ID that might annoy the Where-Object -match
+      $AD_name = [regex]::Escape($AD_name)
+      
+      $SelectedCAP = $Global:CAPs | where-object {$_.Identity -match $CA_name}
+      $OutputBox.Text = ($SelectedCAP | Format-List | Out-String).Trim()
+      if ($SelectedCAP.DialPlan -eq $null)
+      {
+        $DialPlanListbox.SelectedIndex = $DialPlanListbox.findstring("<Automatic>")
+      }
+      else
+      {
+        $DialPlanListbox.SelectedIndex = $DialPlanListbox.findstring("$($SelectedCAP.DialPlan)")
+      }
+      if ($SelectedCAP.VoicePolicy -eq $null)
+      {
+        $VoicePolicyListbox.SelectedIndex = $VoicePolicyListbox.findstring("<Automatic>")
+      }
+      else
+      {
+        $VoicePolicyListbox.SelectedIndex = $VoicePolicyListbox.findstring("$($SelectedCAP.VoicePolicy)")
+      }
+      if ($SelectedCAP.ClientPolicy -eq $null)
+      {
+        $ClientPolicyListbox.SelectedIndex = $ClientPolicyListbox.findstring("<Automatic>")
+      }
+      else
+      {
+        $ClientPolicyListbox.SelectedIndex = $ClientPolicyListbox.findstring("$($SelectedCAP.ClientPolicy)")
+      }
+      if ($SelectedCAP.LocationPolicy -eq $null)
+      {
+        $LocationPolicyListbox.SelectedIndex = $LocationPolicyListbox.findstring("<Automatic>")
+      }
+      else
+      {
+        $LocationPolicyListbox.SelectedIndex = $LocationPolicyListbox.findstring("$($SelectedCAP.LocationPolicy)")
+      }
+    }
 	}
 	else
 	{
@@ -2217,157 +2225,3 @@ WriteSettings $Configfile $Global:DefaultOU $Global:DefaultPool $Global:DefaultS
 
 
 #Code signing certificate kindly provided by Digicert:
-# SIG # Begin signature block
-# MIIceAYJKoZIhvcNAQcCoIIcaTCCHGUCAQExCzAJBgUrDgMCGgUAMGkGCisGAQQB
-# gjcCAQSgWzBZMDQGCisGAQQBgjcCAR4wJgIDAQAABBAfzDtgWUsITrck0sYpfvNR
-# AgEAAgEAAgEAAgEAAgEAMCEwCQYFKw4DAhoFAAQUz6q2P8nAMjdqHm8/yAMdIltN
-# vlCgghenMIIFMDCCBBigAwIBAgIQA1GDBusaADXxu0naTkLwYTANBgkqhkiG9w0B
-# AQsFADByMQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYD
-# VQQLExB3d3cuZGlnaWNlcnQuY29tMTEwLwYDVQQDEyhEaWdpQ2VydCBTSEEyIEFz
-# c3VyZWQgSUQgQ29kZSBTaWduaW5nIENBMB4XDTIwMDQxNzAwMDAwMFoXDTIxMDcw
-# MTEyMDAwMFowbTELMAkGA1UEBhMCQVUxGDAWBgNVBAgTD05ldyBTb3V0aCBXYWxl
-# czESMBAGA1UEBxMJUGV0ZXJzaGFtMRcwFQYDVQQKEw5HcmVpZyBTaGVyaWRhbjEX
-# MBUGA1UEAxMOR3JlaWcgU2hlcmlkYW4wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAw
-# ggEKAoIBAQC0PMhHbI+fkQcYFNzZHgVAuyE3BErOYAVBsCjZgWFMhqvhEq08El/W
-# PNdtlcOaTPMdyEibyJY8ZZTOepPVjtHGFPI08z5F6BkAmyJ7eFpR9EyCd6JRJZ9R
-# ibq3e2mfqnv2wB0rOmRjnIX6XW6dMdfs/iFaSK4pJAqejme5Lcboea4ZJDCoWOK7
-# bUWkoqlY+CazC/Cb48ZguPzacF5qHoDjmpeVS4/mRB4frPj56OvKns4Nf7gOZpQS
-# 956BgagHr92iy3GkExAdr9ys5cDsTA49GwSabwpwDcgobJ+cYeBc1tGElWHVOx0F
-# 24wBBfcDG8KL78bpqOzXhlsyDkOXKM21AgMBAAGjggHFMIIBwTAfBgNVHSMEGDAW
-# gBRaxLl7KgqjpepxA8Bg+S32ZXUOWDAdBgNVHQ4EFgQUzBwyYxT+LFH+GuVtHo2S
-# mSHS/N0wDgYDVR0PAQH/BAQDAgeAMBMGA1UdJQQMMAoGCCsGAQUFBwMDMHcGA1Ud
-# HwRwMG4wNaAzoDGGL2h0dHA6Ly9jcmwzLmRpZ2ljZXJ0LmNvbS9zaGEyLWFzc3Vy
-# ZWQtY3MtZzEuY3JsMDWgM6Axhi9odHRwOi8vY3JsNC5kaWdpY2VydC5jb20vc2hh
-# Mi1hc3N1cmVkLWNzLWcxLmNybDBMBgNVHSAERTBDMDcGCWCGSAGG/WwDATAqMCgG
-# CCsGAQUFBwIBFhxodHRwczovL3d3dy5kaWdpY2VydC5jb20vQ1BTMAgGBmeBDAEE
-# ATCBhAYIKwYBBQUHAQEEeDB2MCQGCCsGAQUFBzABhhhodHRwOi8vb2NzcC5kaWdp
-# Y2VydC5jb20wTgYIKwYBBQUHMAKGQmh0dHA6Ly9jYWNlcnRzLmRpZ2ljZXJ0LmNv
-# bS9EaWdpQ2VydFNIQTJBc3N1cmVkSURDb2RlU2lnbmluZ0NBLmNydDAMBgNVHRMB
-# Af8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCtV/Nu/2vgu+rHGFI6gssYWfYLEwXO
-# eJqOYcYYjb7dk5sRTninaUpKt4WPuFo9OroNOrw6bhvPKdzYArXLCGbnvi40LaJI
-# AOr9+V/+rmVrHXcYxQiWLwKI5NKnzxB2sJzM0vpSzlj1+fa5kCnpKY6qeuv7QUCZ
-# 1+tHunxKW2oF+mBD1MV2S4+Qgl4pT9q2ygh9DO5TPxC91lbuT5p1/flI/3dHBJd+
-# KZ9vYGdsJO5vS4MscsCYTrRXvgvj0wl+Nwumowu4O0ROqLRdxCZ+1X6a5zNdrk4w
-# Dbdznv3E3s3My8Axuaea4WHulgAvPosFrB44e/VHDraIcNCx/GBKNYs8MIIFMDCC
-# BBigAwIBAgIQBAkYG1/Vu2Z1U0O1b5VQCDANBgkqhkiG9w0BAQsFADBlMQswCQYD
-# VQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3d3cuZGln
-# aWNlcnQuY29tMSQwIgYDVQQDExtEaWdpQ2VydCBBc3N1cmVkIElEIFJvb3QgQ0Ew
-# HhcNMTMxMDIyMTIwMDAwWhcNMjgxMDIyMTIwMDAwWjByMQswCQYDVQQGEwJVUzEV
-# MBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3d3cuZGlnaWNlcnQuY29t
-# MTEwLwYDVQQDEyhEaWdpQ2VydCBTSEEyIEFzc3VyZWQgSUQgQ29kZSBTaWduaW5n
-# IENBMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA+NOzHH8OEa9ndwfT
-# CzFJGc/Q+0WZsTrbRPV/5aid2zLXcep2nQUut4/6kkPApfmJ1DcZ17aq8JyGpdgl
-# rA55KDp+6dFn08b7KSfH03sjlOSRI5aQd4L5oYQjZhJUM1B0sSgmuyRpwsJS8hRn
-# iolF1C2ho+mILCCVrhxKhwjfDPXiTWAYvqrEsq5wMWYzcT6scKKrzn/pfMuSoeU7
-# MRzP6vIK5Fe7SrXpdOYr/mzLfnQ5Ng2Q7+S1TqSp6moKq4TzrGdOtcT3jNEgJSPr
-# CGQ+UpbB8g8S9MWOD8Gi6CxR93O8vYWxYoNzQYIH5DiLanMg0A9kczyen6Yzqf0Z
-# 3yWT0QIDAQABo4IBzTCCAckwEgYDVR0TAQH/BAgwBgEB/wIBADAOBgNVHQ8BAf8E
-# BAMCAYYwEwYDVR0lBAwwCgYIKwYBBQUHAwMweQYIKwYBBQUHAQEEbTBrMCQGCCsG
-# AQUFBzABhhhodHRwOi8vb2NzcC5kaWdpY2VydC5jb20wQwYIKwYBBQUHMAKGN2h0
-# dHA6Ly9jYWNlcnRzLmRpZ2ljZXJ0LmNvbS9EaWdpQ2VydEFzc3VyZWRJRFJvb3RD
-# QS5jcnQwgYEGA1UdHwR6MHgwOqA4oDaGNGh0dHA6Ly9jcmw0LmRpZ2ljZXJ0LmNv
-# bS9EaWdpQ2VydEFzc3VyZWRJRFJvb3RDQS5jcmwwOqA4oDaGNGh0dHA6Ly9jcmwz
-# LmRpZ2ljZXJ0LmNvbS9EaWdpQ2VydEFzc3VyZWRJRFJvb3RDQS5jcmwwTwYDVR0g
-# BEgwRjA4BgpghkgBhv1sAAIEMCowKAYIKwYBBQUHAgEWHGh0dHBzOi8vd3d3LmRp
-# Z2ljZXJ0LmNvbS9DUFMwCgYIYIZIAYb9bAMwHQYDVR0OBBYEFFrEuXsqCqOl6nED
-# wGD5LfZldQ5YMB8GA1UdIwQYMBaAFEXroq/0ksuCMS1Ri6enIZ3zbcgPMA0GCSqG
-# SIb3DQEBCwUAA4IBAQA+7A1aJLPzItEVyCx8JSl2qB1dHC06GsTvMGHXfgtg/cM9
-# D8Svi/3vKt8gVTew4fbRknUPUbRupY5a4l4kgU4QpO4/cY5jDhNLrddfRHnzNhQG
-# ivecRk5c/5CxGwcOkRX7uq+1UcKNJK4kxscnKqEpKBo6cSgCPC6Ro8AlEeKcFEeh
-# emhor5unXCBc2XGxDI+7qPjFEmifz0DLQESlE/DmZAwlCEIysjaKJAL+L3J+HNdJ
-# RZboWR3p+nRka7LrZkPas7CM1ekN3fYBIM6ZMWM9CBoYs4GbT8aTEAb8B4H6i9r5
-# gkn3Ym6hU/oSlBiFLpKR6mhsRDKyZqHnGKSaZFHvMIIGajCCBVKgAwIBAgIQAwGa
-# Ajr/WLFr1tXq5hfwZjANBgkqhkiG9w0BAQUFADBiMQswCQYDVQQGEwJVUzEVMBMG
-# A1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3d3cuZGlnaWNlcnQuY29tMSEw
-# HwYDVQQDExhEaWdpQ2VydCBBc3N1cmVkIElEIENBLTEwHhcNMTQxMDIyMDAwMDAw
-# WhcNMjQxMDIyMDAwMDAwWjBHMQswCQYDVQQGEwJVUzERMA8GA1UEChMIRGlnaUNl
-# cnQxJTAjBgNVBAMTHERpZ2lDZXJ0IFRpbWVzdGFtcCBSZXNwb25kZXIwggEiMA0G
-# CSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCjZF38fLPggjXg4PbGKuZJdTvMbuBT
-# qZ8fZFnmfGt/a4ydVfiS457VWmNbAklQ2YPOb2bu3cuF6V+l+dSHdIhEOxnJ5fWR
-# n8YUOawk6qhLLJGJzF4o9GS2ULf1ErNzlgpno75hn67z/RJ4dQ6mWxT9RSOOhkRV
-# fRiGBYxVh3lIRvfKDo2n3k5f4qi2LVkCYYhhchhoubh87ubnNC8xd4EwH7s2AY3v
-# J+P3mvBMMWSN4+v6GYeofs/sjAw2W3rBerh4x8kGLkYQyI3oBGDbvHN0+k7Y/qpA
-# 8bLOcEaD6dpAoVk62RUJV5lWMJPzyWHM0AjMa+xiQpGsAsDvpPCJEY93AgMBAAGj
-# ggM1MIIDMTAOBgNVHQ8BAf8EBAMCB4AwDAYDVR0TAQH/BAIwADAWBgNVHSUBAf8E
-# DDAKBggrBgEFBQcDCDCCAb8GA1UdIASCAbYwggGyMIIBoQYJYIZIAYb9bAcBMIIB
-# kjAoBggrBgEFBQcCARYcaHR0cHM6Ly93d3cuZGlnaWNlcnQuY29tL0NQUzCCAWQG
-# CCsGAQUFBwICMIIBVh6CAVIAQQBuAHkAIAB1AHMAZQAgAG8AZgAgAHQAaABpAHMA
-# IABDAGUAcgB0AGkAZgBpAGMAYQB0AGUAIABjAG8AbgBzAHQAaQB0AHUAdABlAHMA
-# IABhAGMAYwBlAHAAdABhAG4AYwBlACAAbwBmACAAdABoAGUAIABEAGkAZwBpAEMA
-# ZQByAHQAIABDAFAALwBDAFAAUwAgAGEAbgBkACAAdABoAGUAIABSAGUAbAB5AGkA
-# bgBnACAAUABhAHIAdAB5ACAAQQBnAHIAZQBlAG0AZQBuAHQAIAB3AGgAaQBjAGgA
-# IABsAGkAbQBpAHQAIABsAGkAYQBiAGkAbABpAHQAeQAgAGEAbgBkACAAYQByAGUA
-# IABpAG4AYwBvAHIAcABvAHIAYQB0AGUAZAAgAGgAZQByAGUAaQBuACAAYgB5ACAA
-# cgBlAGYAZQByAGUAbgBjAGUALjALBglghkgBhv1sAxUwHwYDVR0jBBgwFoAUFQAS
-# KxOYspkH7R7for5XDStnAs0wHQYDVR0OBBYEFGFaTSS2STKdSip5GoNL9B6Jwcp9
-# MH0GA1UdHwR2MHQwOKA2oDSGMmh0dHA6Ly9jcmwzLmRpZ2ljZXJ0LmNvbS9EaWdp
-# Q2VydEFzc3VyZWRJRENBLTEuY3JsMDigNqA0hjJodHRwOi8vY3JsNC5kaWdpY2Vy
-# dC5jb20vRGlnaUNlcnRBc3N1cmVkSURDQS0xLmNybDB3BggrBgEFBQcBAQRrMGkw
-# JAYIKwYBBQUHMAGGGGh0dHA6Ly9vY3NwLmRpZ2ljZXJ0LmNvbTBBBggrBgEFBQcw
-# AoY1aHR0cDovL2NhY2VydHMuZGlnaWNlcnQuY29tL0RpZ2lDZXJ0QXNzdXJlZElE
-# Q0EtMS5jcnQwDQYJKoZIhvcNAQEFBQADggEBAJ0lfhszTbImgVybhs4jIA+Ah+WI
-# //+x1GosMe06FxlxF82pG7xaFjkAneNshORaQPveBgGMN/qbsZ0kfv4gpFetW7ea
-# sGAm6mlXIV00Lx9xsIOUGQVrNZAQoHuXx/Y/5+IRQaa9YtnwJz04HShvOlIJ8Oxw
-# YtNiS7Dgc6aSwNOOMdgv420XEwbu5AO2FKvzj0OncZ0h3RTKFV2SQdr5D4HRmXQN
-# JsQOfxu19aDxxncGKBXp2JPlVRbwuwqrHNtcSCdmyKOLChzlldquxC5ZoGHd2vNt
-# omHpigtt7BIYvfdVVEADkitrwlHCCkivsNRu4PQUCjob4489yq9qjXvc2EQwggbN
-# MIIFtaADAgECAhAG/fkDlgOt6gAK6z8nu7obMA0GCSqGSIb3DQEBBQUAMGUxCzAJ
-# BgNVBAYTAlVTMRUwEwYDVQQKEwxEaWdpQ2VydCBJbmMxGTAXBgNVBAsTEHd3dy5k
-# aWdpY2VydC5jb20xJDAiBgNVBAMTG0RpZ2lDZXJ0IEFzc3VyZWQgSUQgUm9vdCBD
-# QTAeFw0wNjExMTAwMDAwMDBaFw0yMTExMTAwMDAwMDBaMGIxCzAJBgNVBAYTAlVT
-# MRUwEwYDVQQKEwxEaWdpQ2VydCBJbmMxGTAXBgNVBAsTEHd3dy5kaWdpY2VydC5j
-# b20xITAfBgNVBAMTGERpZ2lDZXJ0IEFzc3VyZWQgSUQgQ0EtMTCCASIwDQYJKoZI
-# hvcNAQEBBQADggEPADCCAQoCggEBAOiCLZn5ysJClaWAc0Bw0p5WVFypxNJBBo/J
-# M/xNRZFcgZ/tLJz4FlnfnrUkFcKYubR3SdyJxArar8tea+2tsHEx6886QAxGTZPs
-# i3o2CAOrDDT+GEmC/sfHMUiAfB6iD5IOUMnGh+s2P9gww/+m9/uizW9zI/6sVgWQ
-# 8DIhFonGcIj5BZd9o8dD3QLoOz3tsUGj7T++25VIxO4es/K8DCuZ0MZdEkKB4YNu
-# gnM/JksUkK5ZZgrEjb7SzgaurYRvSISbT0C58Uzyr5j79s5AXVz2qPEvr+yJIvJr
-# GGWxwXOt1/HYzx4KdFxCuGh+t9V3CidWfA9ipD8yFGCV/QcEogkCAwEAAaOCA3ow
-# ggN2MA4GA1UdDwEB/wQEAwIBhjA7BgNVHSUENDAyBggrBgEFBQcDAQYIKwYBBQUH
-# AwIGCCsGAQUFBwMDBggrBgEFBQcDBAYIKwYBBQUHAwgwggHSBgNVHSAEggHJMIIB
-# xTCCAbQGCmCGSAGG/WwAAQQwggGkMDoGCCsGAQUFBwIBFi5odHRwOi8vd3d3LmRp
-# Z2ljZXJ0LmNvbS9zc2wtY3BzLXJlcG9zaXRvcnkuaHRtMIIBZAYIKwYBBQUHAgIw
-# ggFWHoIBUgBBAG4AeQAgAHUAcwBlACAAbwBmACAAdABoAGkAcwAgAEMAZQByAHQA
-# aQBmAGkAYwBhAHQAZQAgAGMAbwBuAHMAdABpAHQAdQB0AGUAcwAgAGEAYwBjAGUA
-# cAB0AGEAbgBjAGUAIABvAGYAIAB0AGgAZQAgAEQAaQBnAGkAQwBlAHIAdAAgAEMA
-# UAAvAEMAUABTACAAYQBuAGQAIAB0AGgAZQAgAFIAZQBsAHkAaQBuAGcAIABQAGEA
-# cgB0AHkAIABBAGcAcgBlAGUAbQBlAG4AdAAgAHcAaABpAGMAaAAgAGwAaQBtAGkA
-# dAAgAGwAaQBhAGIAaQBsAGkAdAB5ACAAYQBuAGQAIABhAHIAZQAgAGkAbgBjAG8A
-# cgBwAG8AcgBhAHQAZQBkACAAaABlAHIAZQBpAG4AIABiAHkAIAByAGUAZgBlAHIA
-# ZQBuAGMAZQAuMAsGCWCGSAGG/WwDFTASBgNVHRMBAf8ECDAGAQH/AgEAMHkGCCsG
-# AQUFBwEBBG0wazAkBggrBgEFBQcwAYYYaHR0cDovL29jc3AuZGlnaWNlcnQuY29t
-# MEMGCCsGAQUFBzAChjdodHRwOi8vY2FjZXJ0cy5kaWdpY2VydC5jb20vRGlnaUNl
-# cnRBc3N1cmVkSURSb290Q0EuY3J0MIGBBgNVHR8EejB4MDqgOKA2hjRodHRwOi8v
-# Y3JsMy5kaWdpY2VydC5jb20vRGlnaUNlcnRBc3N1cmVkSURSb290Q0EuY3JsMDqg
-# OKA2hjRodHRwOi8vY3JsNC5kaWdpY2VydC5jb20vRGlnaUNlcnRBc3N1cmVkSURS
-# b290Q0EuY3JsMB0GA1UdDgQWBBQVABIrE5iymQftHt+ivlcNK2cCzTAfBgNVHSME
-# GDAWgBRF66Kv9JLLgjEtUYunpyGd823IDzANBgkqhkiG9w0BAQUFAAOCAQEARlA+
-# ybcoJKc4HbZbKa9Sz1LpMUerVlx71Q0LQbPv7HUfdDjyslxhopyVw1Dkgrkj0bo6
-# hnKtOHisdV0XFzRyR4WUVtHruzaEd8wkpfMEGVWp5+Pnq2LN+4stkMLA0rWUvV5P
-# sQXSDj0aqRRbpoYxYqioM+SbOafE9c4deHaUJXPkKqvPnHZL7V/CSxbkS3BMAIke
-# /MV5vEwSV/5f4R68Al2o/vsHOE8Nxl2RuQ9nRc3Wg+3nkg2NsWmMT/tZ4CMP0qqu
-# AHzunEIOz5HXJ7cW7g/DvXwKoO4sCFWFIrjrGBpN/CohrUkxg0eVd3HcsRtLSxwQ
-# nHcUwZ1PL1qVCCkQJjGCBDswggQ3AgEBMIGGMHIxCzAJBgNVBAYTAlVTMRUwEwYD
-# VQQKEwxEaWdpQ2VydCBJbmMxGTAXBgNVBAsTEHd3dy5kaWdpY2VydC5jb20xMTAv
-# BgNVBAMTKERpZ2lDZXJ0IFNIQTIgQXNzdXJlZCBJRCBDb2RlIFNpZ25pbmcgQ0EC
-# EANRgwbrGgA18btJ2k5C8GEwCQYFKw4DAhoFAKB4MBgGCisGAQQBgjcCAQwxCjAI
-# oAKAAKECgAAwGQYJKoZIhvcNAQkDMQwGCisGAQQBgjcCAQQwHAYKKwYBBAGCNwIB
-# CzEOMAwGCisGAQQBgjcCARUwIwYJKoZIhvcNAQkEMRYEFC4KTPW3JPt+/tgIuVBK
-# bNSCR3/NMA0GCSqGSIb3DQEBAQUABIIBAAa9zDmvLbcwmiqyro61gj0PYkis9A+q
-# pshjh2PDrUZ0JeO5n15xRJQ1NerWO5x0E28w6vF+Kn2x2qxXsTTxG6bhbH2FWQu/
-# rxuJD4+rlG7H149q8ZtLpTx/Axu3tUFST0B7ua69+mJBTNmySql6fMfAgvJAV9yh
-# hQJHS5i7hOvVe5RCL5Z5tw02qCeot24fyjyVnP0a9H/8qBgHSxYbK5me/+PBFp1l
-# QG6Sqyjj+T/+lBri9vfDf1WvzYHkw7z3jhoUyymAPGmaSmq6ocgKfjXfzr0+MCdg
-# /2+Jo7wofoCO3vUFdycnNI4yciK30PdY4gaTyFrloy6s/u72Ec+XMXuhggIPMIIC
-# CwYJKoZIhvcNAQkGMYIB/DCCAfgCAQEwdjBiMQswCQYDVQQGEwJVUzEVMBMGA1UE
-# ChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3d3cuZGlnaWNlcnQuY29tMSEwHwYD
-# VQQDExhEaWdpQ2VydCBBc3N1cmVkIElEIENBLTECEAMBmgI6/1ixa9bV6uYX8GYw
-# CQYFKw4DAhoFAKBdMBgGCSqGSIb3DQEJAzELBgkqhkiG9w0BBwEwHAYJKoZIhvcN
-# AQkFMQ8XDTIwMDUwNTExMzc0NFowIwYJKoZIhvcNAQkEMRYEFMdZZnVh4nY8rKvL
-# pKq8FojHt9l7MA0GCSqGSIb3DQEBAQUABIIBAHrlpHRWX2fdNyQs/HC/c0UsT8kw
-# jrJZOrFNyvq43mC+pQcdr1M9Ie6uH1dFg6eJOAtFLlGIdRKFw1XSogQVp1BfqTKk
-# OlCYP0IbOmTXYwY506uvu/iFBLs6EomnwmLUvFVpKNtdoaGgVogpduoFS7BJU0Iq
-# rQMH9jXwwi9rDp3UWbJ658TEa6Wc0BrbMSvzK6FKrDA2A+5v0RBCosti3P23YFsA
-# NNjYrfN/Pf0EMIi/dLAhOcjarzox998fY3kyXriCKwL4WgPMfFnnHRzT5pbSw8da
-# C5UMBhVa9pMp7j1V3FdiOStPMiVlcgsHKIttd9SpRHWAMpUNSbt45tHXGps=
-# SIG # End signature block


### PR DESCRIPTION
Small change to update the selected item object with a simple RegEx Escape line to stop invalid characters annoying the "Where-Object -Match" parameter in the Update-Display function

Removed the code signing certificate as part of the fork, @greiginsydney will need to resign before pulling into Master.
(Also seems ISE Steroids broke formatting...)